### PR TITLE
Update libTorch version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-assets/libtorch-cxx11-abi-shared-with-deps-2.0.1+cpu.zip filter=lfs diff=lfs merge=lfs -text
+assets/libtorch-cxx11-abi-shared-with-deps-2.5.0+cpu.zip filter=lfs diff=lfs merge=lfs -text

--- a/assets/libtorch-cxx11-abi-shared-with-deps-2.0.1+cpu.zip
+++ b/assets/libtorch-cxx11-abi-shared-with-deps-2.0.1+cpu.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2de79972edb9b8b6aebe782e61a090c28cadd2d773a5ca3205f835fb3876e53d
-size 181781261

--- a/assets/libtorch-cxx11-abi-shared-with-deps-2.5.0+cpu.zip
+++ b/assets/libtorch-cxx11-abi-shared-with-deps-2.5.0+cpu.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:848ae52a422bf0bf94fd2ba2b048bb6c3e416f385cef390640760bd0baf7a40e
+size 169497682

--- a/deps/Torch.cmake
+++ b/deps/Torch.cmake
@@ -12,7 +12,7 @@
 
 # using local file
 download_external_project(libtorch
-    URL "file://${PROJECT_SOURCE_DIR}/assets/libtorch-cxx11-abi-shared-with-deps-2.5.0%2Bcpu.zip"
+    URL "file://${PROJECT_SOURCE_DIR}/assets/libtorch-cxx11-abi-shared-with-deps-2.5.0+cpu.zip"
 )
 
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/deps/libtorch")

--- a/deps/Torch.cmake
+++ b/deps/Torch.cmake
@@ -1,11 +1,18 @@
 # libtorch
+# download from the internet (old version)
 # download_external_project(libtorch
 #     URL "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.1%2Bcpu.zip"
 #     PATCH libtorch-optional-c++17.patch
 #     THIRD_PARTY_DIR deps)
 
+# download from the internet (new version)
+# download_external_project(libtorch
+#     URL "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.5.0%2Bcpu.zip"
+#     THIRD_PARTY_DIR deps)
+
+# using local file
 download_external_project(libtorch
-    URL "file://${PROJECT_SOURCE_DIR}/assets/libtorch-cxx11-abi-shared-with-deps-2.0.1+cpu.zip"
+    URL "file://${PROJECT_SOURCE_DIR}/assets/libtorch-cxx11-abi-shared-with-deps-2.5.0%2Bcpu.zip"
 )
 
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/deps/libtorch")


### PR DESCRIPTION
Update libTorch in the project to the latest version to get rid of Segmentation Fault in Augmented Carpentry.